### PR TITLE
Set the title bar of the desktop app in dark mode on Windows and Mac

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -68,6 +68,9 @@ kotlin {
             implementation(compose.ui)
             implementation(compose.components.resources)
 
+            /* Platform Tools */
+            implementation(libs.platformtools.darkmodedetector)
+
             /* Coroutines */
             implementation(libs.kotlinx.coroutines.core)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -69,6 +69,7 @@ kotlin {
             implementation(compose.components.resources)
 
             /* Platform Tools */
+            implementation(libs.platformtools.core)
             implementation(libs.platformtools.darkmodedetector)
 
             /* Coroutines */

--- a/app/src/jvmMain/kotlin/de/stefan_oltmann/mines/Main.kt
+++ b/app/src/jvmMain/kotlin/de/stefan_oltmann/mines/Main.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import de.stefan_oltmann.mines.ui.icons.AppIcon
+import io.github.kdroidfilter.platformtools.darkmodedetector.windows.setWindowsAdaptiveTitleBar
 import java.awt.Dimension
 
 fun main() = application {
@@ -32,7 +33,7 @@ fun main() = application {
         title = APP_TITLE,
         icon = rememberVectorPainter(AppIcon)
     ) {
-
+        window.setWindowsAdaptiveTitleBar(dark = true)
         /*
          * The layout breaks if we allow too small sizes.
          */

--- a/app/src/jvmMain/kotlin/de/stefan_oltmann/mines/Main.kt
+++ b/app/src/jvmMain/kotlin/de/stefan_oltmann/mines/Main.kt
@@ -26,20 +26,22 @@ import de.stefan_oltmann.mines.ui.icons.AppIcon
 import io.github.kdroidfilter.platformtools.darkmodedetector.windows.setWindowsAdaptiveTitleBar
 import java.awt.Dimension
 
-fun main() = application {
+fun main() {
+    System.setProperty("apple.awt.application.appearance", "dark")
+    application {
+        Window(
+            onCloseRequest = ::exitApplication,
+            title = APP_TITLE,
+            icon = rememberVectorPainter(AppIcon)
+        ) {
+            window.setWindowsAdaptiveTitleBar(dark = true)
+            /*
+             * The layout breaks if we allow too small sizes.
+             */
+            this.window.minimumSize = Dimension(600, 600)
 
-    Window(
-        onCloseRequest = ::exitApplication,
-        title = APP_TITLE,
-        icon = rememberVectorPainter(AppIcon)
-    ) {
-        window.setWindowsAdaptiveTitleBar(dark = true)
-        /*
-         * The layout breaks if we allow too small sizes.
-         */
-        this.window.minimumSize = Dimension(600, 600)
+            App()
 
-        App()
-
+        }
     }
 }

--- a/app/src/jvmMain/kotlin/de/stefan_oltmann/mines/Main.kt
+++ b/app/src/jvmMain/kotlin/de/stefan_oltmann/mines/Main.kt
@@ -23,17 +23,22 @@ import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import de.stefan_oltmann.mines.ui.icons.AppIcon
+import io.github.kdroidfilter.platformtools.OperatingSystem
 import io.github.kdroidfilter.platformtools.darkmodedetector.windows.setWindowsAdaptiveTitleBar
+import io.github.kdroidfilter.platformtools.getOperatingSystem
 import java.awt.Dimension
 
 fun main() {
-    System.setProperty("apple.awt.application.appearance", "dark")
+    //Title bar in dark mode on macOS.
+    if (getOperatingSystem() == OperatingSystem.MACOS) System.setProperty("apple.awt.application.appearance", "NSAppearanceNameDarkAqua")
+
     application {
         Window(
             onCloseRequest = ::exitApplication,
             title = APP_TITLE,
             icon = rememberVectorPainter(AppIcon)
         ) {
+            //Title bar in dark mode on Windows.
             window.setWindowsAdaptiveTitleBar(dark = true)
             /*
              * The layout breaks if we allow too small sizes.

--- a/app/src/wasmJsMain/kotlin/de/stefan_oltmann/mines/Main.kt
+++ b/app/src/wasmJsMain/kotlin/de/stefan_oltmann/mines/Main.kt
@@ -22,13 +22,21 @@ package de.stefan_oltmann.mines
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.window.ComposeViewport
 import kotlinx.browser.document
+import org.w3c.dom.HTMLElement
 
 @OptIn(ExperimentalComposeUiApi::class)
 fun main() {
     ComposeViewport(document.body!!) {
-        appLoaded()
+        hideLoader()
         App()
     }
 }
 
-external fun appLoaded()
+// Function to hide the loader and show the app
+fun hideLoader() {
+    val loader = document.getElementById("loader") as? HTMLElement
+    val app = document.getElementById("app") as? HTMLElement
+
+    loader?.style?.display = "none" // Hide the loader
+    app?.style?.display = "block"   // Show the app
+}

--- a/app/src/wasmJsMain/resources/index.html
+++ b/app/src/wasmJsMain/resources/index.html
@@ -19,15 +19,6 @@
 </div>
 </body>
 <script>
-    // Function to hide the loader and show the app
-    function appLoaded() {
-        const loader = document.getElementById("loader");
-        const app = document.getElementById("app");
-        if (loader) loader.style.display = "none"; // Hide the loader
-        if (app) app.style.display = "block";     // Show the app
-        console.log("App is fully loaded!");
-    }
-
     // Register service worker for offline functionality
     if ('serviceWorker' in navigator) {
         window.addEventListener('load', () => {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ kotlin = "2.1.20"
 kotlinx-coroutines = "1.10.2"
 kotlinx-datetime = "0.6.2"
 multiplatformSettings = "1.3.0"
-platformtoolsDarkmodedetector = "0.2.9"
+platformtoolsDark = "0.2.9"
 runtimeAndroid = "1.8.0"
 androidGitVersion = "0.4.14"
 compottie = "2.0.0-rc04"
@@ -32,7 +32,8 @@ compottie-dot = { module = "io.github.alexzhirkevich:compottie-dot", version.ref
 compose-ui-test = { group = "androidx.compose.ui", name = "ui-test", version.ref = "compose-ui-test" }
 compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4", version.ref = "compose-ui-test" }
 compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest", version.ref = "compose-ui-test" }
-platformtools-darkmodedetector = { module = "io.github.kdroidfilter:platformtools.darkmodedetector", version.ref = "platformtoolsDarkmodedetector" }
+platformtools-core = { module = "io.github.kdroidfilter:platformtools.core", version.ref = "platformtoolsDark" }
+platformtools-darkmodedetector = { module = "io.github.kdroidfilter:platformtools.darkmodedetector", version.ref = "platformtoolsDark" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ kotlin = "2.1.20"
 kotlinx-coroutines = "1.10.2"
 kotlinx-datetime = "0.6.2"
 multiplatformSettings = "1.3.0"
+platformtoolsDarkmodedetector = "0.2.9"
 runtimeAndroid = "1.8.0"
 androidGitVersion = "0.4.14"
 compottie = "2.0.0-rc04"
@@ -31,6 +32,7 @@ compottie-dot = { module = "io.github.alexzhirkevich:compottie-dot", version.ref
 compose-ui-test = { group = "androidx.compose.ui", name = "ui-test", version.ref = "compose-ui-test" }
 compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4", version.ref = "compose-ui-test" }
 compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest", version.ref = "compose-ui-test" }
+platformtools-darkmodedetector = { module = "io.github.kdroidfilter:platformtools.darkmodedetector", version.ref = "platformtoolsDarkmodedetector" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Set the title bar of the desktop app in dark mode on Windows and Mac
Move loader of WasmJs handling logic from hardcoded JS to Kotlin JS