### PR TITLE
Set app version from GitHub tag and adjust workflow triggers

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -3,7 +3,7 @@ name: Build & Release Flatpak
 on:
   push:
     tags:
-      - 'v*'
+      - '*'
 
 jobs:
   build-flatpak:
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history and tags
 
       - name: Flatpak info
         run: flatpak --version
@@ -36,7 +38,7 @@ jobs:
       - name: Build Flatpak bundle
         run: ./gradlew packageFlatpakReleaseDistributable
 
-          
+
       - name: Upload Flatpak artifact
         uses: actions/upload-artifact@v4
         with:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -221,7 +221,20 @@ configurations.all {
 tasks {
 
     val appId = "de.stefan_oltmann.mines"
-    val appVersion = version.toString()
+    // Get the tag from GitHub Actions environment variable if available, otherwise use version.toString()
+    val appVersion = System.getenv("GITHUB_REF")?.let { ref ->
+        if (ref.startsWith("refs/tags/")) {
+            val tag = ref.removePrefix("refs/tags/")
+            logger.lifecycle("Using tag from GitHub Actions: $tag")
+            tag
+        } else {
+            logger.lifecycle("GITHUB_REF doesn't start with 'refs/tags/': $ref, falling back to version.toString()")
+            version.toString()
+        }
+    } ?: run {
+        logger.lifecycle("GITHUB_REF not found, falling back to version.toString()")
+        version.toString()
+    }
 
     val packageTarReleaseDistributable by registering(Tar::class) {
         group = "compose desktop"
@@ -282,4 +295,5 @@ tasks {
         description = "Full chain: tar.gz + flatpak"
         dependsOn(bundleFlatpak)
     }
+
 }


### PR DESCRIPTION
Update the build script to derive the app version from GitHub tag references when available, defaulting to `version.toString()`. Modify the GitHub Actions workflow to trigger on all tags and fetch full history to ensure tag availability. These changes improve versioning accuracy and build consistency.